### PR TITLE
Enable automatic experiment result submission

### DIFF
--- a/js/prompt.js
+++ b/js/prompt.js
@@ -4,9 +4,8 @@ const styleDescriptionInput = document.getElementById('style-description-input')
 const submitButton = document.getElementById('submit-button');
 const saveStatus = document.getElementById('save-status');
 
-// Endpoint for automatic submission.
-// Replace YOUR_FORM_ID with the ID from your Formspree form.
-const SUBMIT_ENDPOINT = 'https://formspree.io/f/YOUR_FORM_ID';
+// Endpoint for automatic submission using Formspree.
+const SUBMIT_ENDPOINT = 'https://formspree.io/f/xpwjklwz';
 
 function buildOutputData() {
     const feedbackData = JSON.parse(localStorage.getItem('imageFeedback')) || {};

--- a/js/prompt.js
+++ b/js/prompt.js
@@ -1,11 +1,12 @@
 // Script for prompt.html
 
 const styleDescriptionInput = document.getElementById('style-description-input');
-const saveFinalButton = document.getElementById('save-final-button');
-const backupButton = document.getElementById('backup-button');
-const shareButton = document.getElementById('share-button');
-const copyButton = document.getElementById('copy-button');
+const submitButton = document.getElementById('submit-button');
 const saveStatus = document.getElementById('save-status');
+
+// Endpoint for automatic submission.
+// Replace YOUR_FORM_ID with the ID from your Formspree form.
+const SUBMIT_ENDPOINT = 'https://formspree.io/f/YOUR_FORM_ID';
 
 function buildOutputData() {
     const feedbackData = JSON.parse(localStorage.getItem('imageFeedback')) || {};
@@ -47,159 +48,48 @@ function buildOutputData() {
     };
 }
 
-function saveLocalBackup(jsonStr) {
-    try {
-        const payload = { saved_at: new Date().toISOString(), data: JSON.parse(jsonStr) };
-        localStorage.setItem('imageFeedback_backup', JSON.stringify(payload));
-        if (saveStatus) {
-            saveStatus.textContent = 'Saved local backup.';
-            saveStatus.style.display = 'block';
-        }
-    } catch (e) {
-        console.warn('Failed to save local backup:', e);
-    }
-}
-
-async function shareResults(jsonStr, filename) {
-    try {
-        const file = new File([jsonStr], filename, { type: 'application/json' });
-        if (navigator.canShare && navigator.canShare({ files: [file] })) {
-            await navigator.share({
-                title: 'Study feedback',
-                text: 'Attached is my anonymized study feedback file.',
-                files: [file]
-            });
-            return true;
-        }
-    } catch (err) {
-        console.warn('Web Share failed:', err);
-    }
-    // Fallback: open mailto with instructions (attachment must be manual)
-    const subject = encodeURIComponent('Study feedback JSON');
-    const body = encodeURIComponent(
-        'Hi,\n\nI have saved my anonymized study feedback file. I will attach it to this email.\n' +
-        'If you cannot find the file, it is likely in your Downloads folder.\n\nThank you.'
-    );
-    const recipient = 'mmutny@broadinstitute.org';
-    window.location.href = `mailto:${recipient}?subject=${subject}&body=${body}`;
-    return false;
-}
-
-saveFinalButton.addEventListener('click', async () => {
-    // Retrieve feedback data saved from index.html
+async function submitFeedback() {
     const feedbackData = JSON.parse(localStorage.getItem('imageFeedback')) || {};
-
-    // Get the style description from this page
     const styleDescription = styleDescriptionInput.value.trim();
 
-    // --- Validation ---
-    // Check if style description is entered
     if (styleDescription === '') {
-        alert("Please describe the style you had in mind before saving.");
-        return; // Stop if description is missing
+        alert("Please describe the style you had in mind before submitting.");
+        return;
     }
 
-    // Optional: Check if feedbackData is empty (user somehow skipped the feedback page)
     if (Object.keys(feedbackData).length === 0) {
-        if (!confirm("Warning: No image preferences were found. This usually means the feedback steps were skipped.\n\nDo you want to save the prompts anyway?")) {
-            return; // Stop if user cancels
+        if (!confirm("Warning: No image preferences were found. This usually means the feedback steps were skipped.\n\nDo you want to submit anyway?")) {
+            return;
         }
     }
 
-    // --- Prepare data for JSON ---
-    // Process feedbackData to include detailed info
-    const formattedPreferences = [];
-    const filenamePattern = /^images\/alg-([a-zA-Z0-9]+)_episode_(\d+)_timestep_(\d+)\.png$/i;
-
-    for (const filename in feedbackData) {
-        if (feedbackData.hasOwnProperty(filename)) {
-            const match = filename.match(filenamePattern);
-            if (match) {
-                formattedPreferences.push({
-                    filename: filename, // Keep original filename
-                    algorithm: match[1],
-                    episode: parseInt(match[2], 10),
-                    timestep: parseInt(match[3], 10),
-                    preference: feedbackData[filename] // The user's choice (1-based index)
-                });
-            } else {
-                console.warn(`Could not parse filename in feedback data: ${filename}`);
-                // Optionally include raw data if parsing fails
-                // formattedPreferences.push({ filename: filename, preference: feedbackData[filename], error: "parse_failed" });
-            }
-        }
-    }
-
-    // Sort the preferences for consistency (optional, but good practice)
-    formattedPreferences.sort((a, b) => {
-        if (a.algorithm !== b.algorithm) return a.algorithm.localeCompare(b.algorithm);
-        if (a.episode !== b.episode) return a.episode - b.episode;
-        return a.timestep - b.timestep;
-    });
-
-    // Retrieve benchmark episode keys from localStorage
-    const benchmarkEpisodeKeys = JSON.parse(localStorage.getItem('benchmarkEpisodeKeys')) || [];
-    if (benchmarkEpisodeKeys.length > 0) {
-        console.log("Retrieved benchmarkEpisodeKeys from localStorage:", benchmarkEpisodeKeys);
-    }
-
     const outputData = buildOutputData();
-    const outputJson = JSON.stringify(outputData, null, 2); // Pretty print JSON
-    const blob = new Blob([outputJson], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    // Suggest a filename including the style description (sanitized)
-    const sanitizedDescription = styleDescription.replace(/[^a-z0-9]/gi, '_').toLowerCase().substring(0, 30);
-    a.download = `feedback_${sanitizedDescription || 'data'}.json`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-    console.log("Feedback saved to JSON file.");
-    // Save a backup locally for reliability
-    saveLocalBackup(outputJson);
+    saveStatus.style.display = 'block';
+    saveStatus.textContent = 'Submitting...';
 
-    // Optional: Clear localStorage after saving
-    // localStorage.removeItem('imageFeedback');
-    // alert("Feedback saved successfully!");
-
-    // Optional: Redirect or display a success message
-    saveFinalButton.textContent = "Saved!";
-    saveFinalButton.disabled = true;
-    alert("Feedback saved successfully! Optionally share/email the results or save a local backup.");
-
-});
-
-// Backup button handler
-backupButton?.addEventListener('click', () => {
-    const outputData = buildOutputData();
-    const outputJson = JSON.stringify(outputData, null, 2);
-    saveLocalBackup(outputJson);
-});
-
-// Share/email handler
-shareButton?.addEventListener('click', async () => {
-    const description = styleDescriptionInput.value.trim();
-    const sanitized = description.replace(/[^a-z0-9]/gi, '_').toLowerCase().substring(0, 30) || 'data';
-    const filename = `feedback_${sanitized}.json`;
-    const outputData = buildOutputData();
-    const outputJson = JSON.stringify(outputData, null, 2);
-    await shareResults(outputJson, filename);
-});
-
-// Copy JSON to clipboard handler
-copyButton?.addEventListener('click', async () => {
-    const outputData = buildOutputData();
-    const outputJson = JSON.stringify(outputData, null, 2);
     try {
-        await navigator.clipboard.writeText(outputJson);
-        if (saveStatus) {
-            saveStatus.textContent = 'Copied JSON to clipboard.';
-            saveStatus.style.display = 'block';
+        const response = await fetch(SUBMIT_ENDPOINT, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            },
+            body: JSON.stringify(outputData)
+        });
+        if (response.ok) {
+            saveStatus.textContent = 'Submission successful. Thank you!';
+            submitButton.disabled = true;
+            // Clear stored data to maintain privacy
+            localStorage.removeItem('imageFeedback');
+            localStorage.removeItem('benchmarkEpisodeKeys');
+        } else {
+            console.warn('Submission failed:', response.statusText);
+            saveStatus.textContent = 'Submission failed. Please try again later.';
         }
-    } catch (e) {
-        alert('Copy failed. Please select and copy manually.');
-        console.warn('Clipboard copy failed:', e);
+    } catch (err) {
+        console.error('Submission error:', err);
+        saveStatus.textContent = 'Submission failed. Please try again later.';
     }
-});
+}
+
+submitButton.addEventListener('click', submitFeedback);

--- a/prompt.html
+++ b/prompt.html
@@ -37,7 +37,7 @@
             font-family: sans-serif; /* Ensure textarea font matches */
             resize: vertical; /* Allow vertical resize */
         }
-        #save-final-button { /* Use a unique ID */
+        #submit-button { /* Submit button styling */
             padding: 12px 25px;
             font-size: 1.1em;
             cursor: pointer;
@@ -61,12 +61,9 @@
         <textarea id="style-description-input" name="style_description" rows="4" placeholder="e.g., vintage photo, cartoonish, like a roman fresco..."></textarea>
 
         <div style="margin-top: 12px; display: flex; gap: 10px; flex-wrap: wrap; justify-content:center;">
-            <button id="save-final-button">Save Feedback</button>
-            <button id="backup-button" type="button">Save Local Backup</button>
-            <button id="share-button" type="button">Share / Email Results</button>
-            <button id="copy-button" type="button">Copy JSON</button>
+            <button id="submit-button">Submit Feedback</button>
         </div>
-        <p id="save-status" style="margin-top:10px;color:#2a6;display:none;">Saved locally.</p>
+        <p id="save-status" style="margin-top:10px;color:#2a6;display:none;">Submitting...</p>
     </div>
 
     <!-- Load the script for this page -->


### PR DESCRIPTION
## Summary
- Replace manual JSON download flow with automatic submission to a Formspree endpoint
- Simplify prompt page UI to a single **Submit Feedback** button with status messages

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check js/prompt.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd80cfdf10832a8092af030877a613